### PR TITLE
unicode support

### DIFF
--- a/google.el
+++ b/google.el
@@ -73,6 +73,11 @@ Note that this is required by Google's terms of service."
 (defun google-response (buf)
   "Extract the JSON response from BUF."
   (with-current-buffer buf
+    (setq case-fold-search nil)
+    (save-excursion
+      (goto-char (point-min))
+      (when (re-search-forward "charset=utf-8" nil t)
+        (set-buffer-multibyte t)))
     (goto-char url-http-end-of-headers)
     (prog1 (json-read)
       (kill-buffer buf))))


### PR DESCRIPTION
the coding-system of the process buffer is not utf-8 and hence unicode characters are messed up in the result. this change checks if "charset=utf-8" is present in the header and sets the buffer to multibyte which will save us from despair
